### PR TITLE
Issue #47: cim_uint32 unsigned 32 bit integer values are improperly converted to int

### DIFF
--- a/src/main/java/org/metricshub/wmi/wbem/WmiCimTypeHandler.java
+++ b/src/main/java/org/metricshub/wmi/wbem/WmiCimTypeHandler.java
@@ -68,7 +68,7 @@ public class WmiCimTypeHandler {
 
 		map.put(Wbemcli.CIM_UINT8, ByReference::byteValue);
 		map.put(Wbemcli.CIM_UINT16, ByReference::intValue);
-		map.put(Wbemcli.CIM_UINT32, ByReference::longValue);
+		map.put(Wbemcli.CIM_UINT32, WmiCimTypeHandler::convertCimUint32);
 		map.put(Wbemcli.CIM_UINT64, ByReference::stringValue);
 		map.put(Wbemcli.CIM_SINT8, ByReference::shortValue);
 		map.put(Wbemcli.CIM_SINT16, ByReference::shortValue);
@@ -88,6 +88,22 @@ public class WmiCimTypeHandler {
 	}
 
 	private static final String CIM_OBJECT_LABEL = "CIM_OBJECT";
+
+	/**
+	 * Convert a ByReference value holding a CIM_UINT32 (i.e. an unsigned int on 32 bits).
+	 * <p>
+	 * Unfortunately, there seems to be a bug in either JNA or Wbemcli library which stores
+	 * CIM_UINT32 values as VT_I4 (signed integer). As a result, it's converted to a signed
+	 * integer, which is wrong.
+	 * <p>
+	 * Good news, since we know the CIM type, we can enforce reconverting to unsigned!
+	 * <p>
+	 * @param cimUint32Value a CIM_UINT32 value... potentially (and wrongly) stored as a VT_I4
+	 * @return always a positive long
+	 */
+	private static long convertCimUint32(final ByReference cimUint32Value) {
+		return Integer.toUnsignedLong(cimUint32Value.intValue());
+	}
 
 	/**
 	 * Convert a ByReference value holding a CIM_DATETIME (i.e. a string in the form

--- a/src/test/java/org/metricshub/wmi/wbem/WmiCimTypeHandlerTest.java
+++ b/src/test/java/org/metricshub/wmi/wbem/WmiCimTypeHandlerTest.java
@@ -80,16 +80,34 @@ class WmiCimTypeHandlerTest {
 
 	@Test
 	void testConvertCIM_UINT32() {
-		long testLong = 2 << 33;
-		ByReference r = new ByReference(new VARIANT(testLong));
-		assertEquals(
-			Collections.singletonMap("uint32Property", testLong),
-			WmiCimTypeHandler.convert(
-				r,
-				Wbemcli.CIM_UINT32,
-				new AbstractMap.SimpleEntry<String, Set<String>>("uint32Property", Collections.emptySet())
-			)
-		);
+		// Make sure CIM_UINT32 are returned as long
+		{
+			long testLong = 1L << (31 + 12345); // a value between 2^31 and 2^32 - 1
+			ByReference r = new ByReference(new VARIANT(testLong));
+			assertEquals(
+				Collections.singletonMap("uint32Property", testLong),
+				WmiCimTypeHandler.convert(
+					r,
+					Wbemcli.CIM_UINT32,
+					new AbstractMap.SimpleEntry<String, Set<String>>("uint32Property", Collections.emptySet())
+				)
+			);
+		}
+
+		// Test the special case where CIM_UINT32 is actually stored as... a signed integer!
+		// A positive long must be returned
+		{
+			// -1 == 2^32 - 1
+			ByReference r = new ByReference(new VARIANT(-1));
+			assertEquals(
+				Collections.singletonMap("uint32Property", (1L << 32) - 1),
+				WmiCimTypeHandler.convert(
+					r,
+					Wbemcli.CIM_UINT32,
+					new AbstractMap.SimpleEntry<String, Set<String>>("uint32Property", Collections.emptySet())
+				)
+			);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Issue #47 reopened because CIM_UINT32 values **may** be incorrectly stored by Wbemcli/JNA/DCOM as integers, so we need to fix these values as positive long specifically.